### PR TITLE
fix: GitHub sync event name

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ module.exports = app => {
   app.on([
     'pull_request.opened',
     'pull_request.reopened',
-    'pull_request.synchronized',
+    'pull_request.synchronize',
     'pull_request.edited'], async context => {
 
     const pullRequest = context.payload.pull_request;

--- a/tests/test.js
+++ b/tests/test.js
@@ -96,7 +96,7 @@ describe('Size', () => {
   test('creates a label when a pull request is synchronized', async () => {
     // Simulates delivery of an issues.opened webhook
     await app.receive({
-      name: 'pull_request.synchronized',
+      name: 'pull_request.synchronize',
       payload: pullRequestSynchronizedPayload
     })
 


### PR DESCRIPTION
According [documentation](https://developer.github.com/v3/activity/events/types/#pullrequestevent), I corrected the event name. Or it doesn't update labels when you push new commits.