### PR TITLE
Fix sls deploy: write env vars to file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,11 @@
 name: Deploy
 
-on:
-  push:
-    branches:
-      - master
-  workflow_dispatch: {}
+on: push
+# on:
+#   push:
+#     branches:
+#       - master
+#   workflow_dispatch: {}
 
 jobs:
   deploy:
@@ -20,7 +21,8 @@ jobs:
       - name: serverless deploy
         uses: serverless/github-action@master
         with:
-          args: deploy
+          args: -c 'printenv | grep "PRIVATE_KEY\|APP_ID\|WEBHOOK_SECRET" > .env && serverless deploy --verbose && rm .env'
+          entrypoint: /bin/bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         uses: serverless/github-action@master
         with:
           args: -c 'printenv | grep "PRIVATE_KEY\|APP_ID\|WEBHOOK_SECRET" > .env && serverless deploy --verbose && rm .env'
-          entrypoint: /bin/bash
+          entrypoint: /bin/sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,10 @@
 name: Deploy
 
-on: push
-# on:
-#   push:
-#     branches:
-#       - master
-#   workflow_dispatch: {}
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: {}
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: serverless deploy
         uses: serverless/github-action@master
         with:
-          args: -c 'printenv | grep "PRIVATE_KEY\|APP_ID\|WEBHOOK_SECRET" > .env && serverless deploy --verbose && rm .env'
+          args: -c "printenv | grep 'PRIVATE_KEY\|APP_ID\|WEBHOOK_SECRET' > .env && serverless deploy --verbose && rm .env"
           entrypoint: /bin/sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Serverless expects env vars to be in a file to be used as `${env.MY_ENV}` in serverless.yml