### PR TITLE
Allow global configuration using the .github repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7201,21 +7201,6 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
-    "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "requires": {
-        "argparse": "^2.0.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        }
-      }
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@noqcks/generated": "^1.0.1",
     "@probot/adapter-aws-lambda-serverless": "^2.0.2",
     "@sentry/node": "^4.3.0",
-    "js-yaml": "^4.1.0",
     "minimatch": "^3.0.4",
     "probot": "^11.0.6"
   },


### PR DESCRIPTION
Hello

Thank you for sharing this great app,
I find it very useful.

The current implementation, uses _octokit_'s [repos.getContent][0] function to retrieve the _label.yml_
configuration file from the current repo.</br>

Replacing it with _probot_'s [config][1] function will also try to retrieve the _label.yml_ configuration
file from the user's .github repo, if failed to find one the current repo.

Doing this will allow the usage of one global configuration file for all repositories not containing their own.

I can share links to other public bots that use the same technique.

[0]: https://octokit.github.io/rest.js/v18#repos-get-content
[1]: https://probot.github.io/api/latest/classes/context.Context.html#config

