### PR TITLE
Fix linguist generated support

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -87,7 +87,7 @@ async function getCustomGeneratedFiles(ctx, owner, repo) {
     const lines = buff.toString('ascii').split('\n');
 
     lines.forEach((item) => {
-      if (item.includes('linguist-generated=true')) {
+      if (/linguist-generated(?:=true)?\b(?!=false)/.test(item)) {
         files.push(item.split(' ')[0]);
       }
     });


### PR DESCRIPTION
`linguist-generated` can also be valid without a =true

https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#generated-code

related to https://github.com/noqcks/pull-request-size/issues/133
