### PR TITLE
update sentry to 7.120.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,3 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Sentry](https://img.shields.io/badge/sentry-enabled-green)](https://sentry.io)
 [![Build Status](https://github.com/noqcks/pull-request-size/workflows/Test/badge.svg)](https://github.com/noqcks/pull-request-size/actions)
-[![codecov](https://codecov.io/gh/noqcks/pull-request-size/branch/master/graph/badge.svg?token=qw3AMD6G8H)](https://codecov.io/gh/noqcks/pull-request-size)
 [![Dependabot](https://badgen.net/badge/Dependabot/enabled/green?icon=dependabot)](https://dependabot.com/)
 
 Pull Request Size is a GitHub App that applies `size/*` labels to Pull Requests based on the total lines of code changed (additions and deletions).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noqcks/generated": "^7.23.0",
         "@probot/adapter-aws-lambda-serverless": "^3.0.2",
-        "@sentry/node": "^7.58.0",
+        "@sentry/node": "^7.120.0",
         "minimatch": "^5.1.6",
         "probot": "^12.3.1",
         "serverless": "^3.33.0"
@@ -1642,65 +1642,79 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.58.0.tgz",
-      "integrity": "sha512-7V/vkFFYCmSq25er3Y0wukkTM940Wvk9qjh7kWcCCeesKFHNGBCP7HVZhsymjPIJGGJTvRWc9MgBzRGe/c16Xg==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.0.tgz",
+      "integrity": "sha512-VymJoIGMV0PcTJyshka9uJ1sKpR7bHooqW5jTEr6g0dYAwB723fPXHjVW+7SETF7i5+yr2KMprYKreqRidKyKA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.58.0",
-        "@sentry/types": "7.58.0",
-        "@sentry/utils": "7.58.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.58.0.tgz",
-      "integrity": "sha512-tdz+HOh9blnfJ4ZSfsaVaSh/i7pD2QfmC0///fWlNm+IvD+SAgYFP6M3PIsJMsaN5heZ9XMNY4wnxvd+vvJwPQ==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.58.0",
-        "@sentry/utils": "7.58.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.0.tgz",
+      "integrity": "sha512-/Hs9MgSmG4JFNyeQkJ+MWh/fxO/U38Pz0VSH3hDrfyCjI8vH9Vz9inGEQXgB9Ke4eH8XnhsQ7xPnM27lWJts6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.58.0.tgz",
-      "integrity": "sha512-Br6l0XuBEI13dektlPi0jvaVrUEirL7Z61SvbdjR8C/G6O9TXw0wKwc/BXf1GYV5JP7jsWHdRQEO2s45mtmNwQ==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.120.0.tgz",
+      "integrity": "sha512-GAyuNd8WUznsiOyDq2QUwR/aVnMmItUc4tgZQxhH1R+n4Adx3cAhnpq3zEuzsIAC5+/7ut+4Q4B3akh6SDZd4w==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.58.0",
-        "@sentry/core": "7.58.0",
-        "@sentry/types": "7.58.0",
-        "@sentry/utils": "7.58.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/integrations": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.58.0.tgz",
-      "integrity": "sha512-uy8rww5R0WSxr9kB1R1BXWomkKXosK+jOFslbIda4CfTiAMEINi7rXkqTzPJKCIRLHFvKXDFUIkMCHNMkgYjwA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.58.0.tgz",
-      "integrity": "sha512-EAknRDovGBnIVvGLJVxPbB1gUY/VCUoVov26Fk1BYLtUmWlzt+JYHsBJptHw15onu+M0em7z7Iax4wKoiNhhzA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.58.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.120.0"
       },
       "engines": {
         "node": ">=8"
@@ -7922,6 +7936,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
+    "node_modules/localforage/node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -12859,53 +12891,58 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.58.0.tgz",
-      "integrity": "sha512-7V/vkFFYCmSq25er3Y0wukkTM940Wvk9qjh7kWcCCeesKFHNGBCP7HVZhsymjPIJGGJTvRWc9MgBzRGe/c16Xg==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.0.tgz",
+      "integrity": "sha512-VymJoIGMV0PcTJyshka9uJ1sKpR7bHooqW5jTEr6g0dYAwB723fPXHjVW+7SETF7i5+yr2KMprYKreqRidKyKA==",
       "requires": {
-        "@sentry/core": "7.58.0",
-        "@sentry/types": "7.58.0",
-        "@sentry/utils": "7.58.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/core": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.58.0.tgz",
-      "integrity": "sha512-tdz+HOh9blnfJ4ZSfsaVaSh/i7pD2QfmC0///fWlNm+IvD+SAgYFP6M3PIsJMsaN5heZ9XMNY4wnxvd+vvJwPQ==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
       "requires": {
-        "@sentry/types": "7.58.0",
-        "@sentry/utils": "7.58.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.0.tgz",
+      "integrity": "sha512-/Hs9MgSmG4JFNyeQkJ+MWh/fxO/U38Pz0VSH3hDrfyCjI8vH9Vz9inGEQXgB9Ke4eH8XnhsQ7xPnM27lWJts6g==",
+      "requires": {
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0",
+        "localforage": "^1.8.1"
       }
     },
     "@sentry/node": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.58.0.tgz",
-      "integrity": "sha512-Br6l0XuBEI13dektlPi0jvaVrUEirL7Z61SvbdjR8C/G6O9TXw0wKwc/BXf1GYV5JP7jsWHdRQEO2s45mtmNwQ==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.120.0.tgz",
+      "integrity": "sha512-GAyuNd8WUznsiOyDq2QUwR/aVnMmItUc4tgZQxhH1R+n4Adx3cAhnpq3zEuzsIAC5+/7ut+4Q4B3akh6SDZd4w==",
       "requires": {
-        "@sentry-internal/tracing": "7.58.0",
-        "@sentry/core": "7.58.0",
-        "@sentry/types": "7.58.0",
-        "@sentry/utils": "7.58.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/integrations": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/types": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.58.0.tgz",
-      "integrity": "sha512-uy8rww5R0WSxr9kB1R1BXWomkKXosK+jOFslbIda4CfTiAMEINi7rXkqTzPJKCIRLHFvKXDFUIkMCHNMkgYjwA=="
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA=="
     },
     "@sentry/utils": {
-      "version": "7.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.58.0.tgz",
-      "integrity": "sha512-EAknRDovGBnIVvGLJVxPbB1gUY/VCUoVov26Fk1BYLtUmWlzt+JYHsBJptHw15onu+M0em7z7Iax4wKoiNhhzA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
       "requires": {
-        "@sentry/types": "7.58.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.120.0"
       }
     },
     "@serverless/dashboard-plugin": {
@@ -17659,6 +17696,24 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
           "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+        }
+      }
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "requires": {
+        "lie": "3.1.1"
+      },
+      "dependencies": {
+        "lie": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+          "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+          "requires": {
+            "immediate": "~3.0.5"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@noqcks/generated": "^7.23.0",
     "@probot/adapter-aws-lambda-serverless": "^3.0.2",
-    "@sentry/node": "^7.58.0",
+    "@sentry/node": "^7.120.0",
     "minimatch": "^5.1.6",
     "probot": "^12.3.1",
     "serverless": "^3.33.0"

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,7 +12,7 @@ provider:
     PRIVATE_KEY: ${env:PRIVATE_KEY}
     WEBHOOK_SECRET: ${env:WEBHOOK_SECRET}
     NODE_ENV: production
-    LOG_LEVEL: debug
+    LOG_LEVEL: info
     SENTRY_DSN: https://390c9d912ff048649882442625c3aa7d@o4504364806176768.ingest.sentry.io/4504364812795904
 
 functions:


### PR DESCRIPTION
need sentry 7.64+ to get rid of an error on deploy


```
scope.getPropagationContext is not a function
```

https://github.com/getsentry/sentry-javascript/issues/8538